### PR TITLE
chore: bump to get rid of node16 github actions deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'strict'
 runs:
-  using: node16
+  using: node20
   main: ./dist/index.js


### PR DESCRIPTION
Example
![Screenshot 2024-04-23 at 10 32 51](https://github.com/xom9ikk/dotenv/assets/76173161/01983bb3-86b6-47ed-89a6-a1f30fc8fd82)
