### PR TITLE
Revert "chore: bump to get rid of node16 github actions deprecation warnings"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'strict'
 runs:
-  using: node20
+  using: node16
   main: ./dist/index.js


### PR DESCRIPTION
Reverts pactiotech/dotenv#1

So that we can sync with the forked repo instead as they have also bumped the version. Will help avoid diverging conflicts in case we want to use more down the line